### PR TITLE
adding metric from paper

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Lyrics alignment models can be evaluated with our Evaluate.py function according
   * Mean AE, standard deviation over songs
 * Percentage of correct segments (Perc) metric, averaged over songs
 * [Mauch metric](https://citeseerx.ist.psu.edu/viewdoc/summary?doi=10.1.1.310.799) (with different tolerance values)
+* [Perceptually weighted synchronicity score](https://zenodo.org/record/5625688) (thanks to Ninon Lizé Masclef and Manuel Moussallam for the implementation)
 
 ### Reproducing the paper results
 


### PR DESCRIPTION
Implementing the metric based on human synchronicity perception as measured in the paper:

 "User-centered evaluation of lyrics to audio alignment", N. Lizé-Masclef, A. Vaglio, M. Moussallam, ISMIR 2021 

This allows to reproduce the results from Table 1, and anyone to use it in their Jamendo alignment benchmarks  