### PR TITLE
Make newlines in lyrics consistent with annotations

### DIFF
--- a/lyrics/JASON_MILLER_-_CROWD_PLEASER.txt
+++ b/lyrics/JASON_MILLER_-_CROWD_PLEASER.txt
@@ -20,24 +20,17 @@ shine off me
 wait for it
 wait for it
 wait for it
-don't worry the
-my haters is gonna pay for it
-chase dreams dumb
-niggas chase whores
-over sea's
-on a great tour
+don't worry the my haters is gonna pay for it
+chase dreams dumb niggas chase whores
+over sea's on a great tour
 or maybe i'm just dreaming
 it beats being with demons or
-a nigga scheming or
-at least im thinking of an achievement
+a nigga scheming or at least im thinking of an achievement
 people talk shit for four seasons
 for no reason
-people dog lebron until
-lebron show up
-when he step on the paint then their
-guards go up
-scores up
-all the applauds go up
+people dog lebron until lebron show up
+when he step on the paint then their guards go up
+scores up all the applauds go up
 and everybody in the whole damn court goes nuts
 
 people gonna hate let them do it
@@ -56,35 +49,22 @@ spectators
 side liners
 spending days
 coming up with sly comments
-that's
-psychotic
-why try a tarnish
-such a fly product
+that's psychotic why try a tarnish such a fly product
 why be mad just cause i got hey
 i may never know
-wave to the haters
-that put me on the pedestal
-talk smack
-but they really
-know i'm incredible
+wave to the haters that put me on the pedestal talk smack
+but they really know i'm incredible
 unforgettable young blue eyes
-the new guy
-is on schedule
+the new guy is on schedule
 man behind bars and thats minus the federal
 stone giant what the hell
 could some pebbles do
-while you revel in drama
-im building revenue
-tell them you'll get them tomorrow their ain't
-nothing stressing you
-life goes on
-lifes goes on
-you was the shit even
-before those lights went on
-they gonna trash you
-even if they like your song
-people always gonna judge homie
-right or wrong
+while you revel in drama im building revenue
+tell them you'll get them tomorrow their ain't nothing stressing you
+life goes on lifes goes on
+you was the shit even before those lights went on
+they gonna trash you even if they like your song
+people always gonna judge homie right or wrong
 
 people gonna hate let them do it
 shine like it ain't nothing to it

--- a/lyrics/Moon_I_Mean_-_Wrong_Concept.txt
+++ b/lyrics/Moon_I_Mean_-_Wrong_Concept.txt
@@ -45,4 +45,5 @@ but i wished just your honey
 i burnt your t shirt that one with bunny
 and now about you nothing more of funny
 wrong concept wrong concept to love
-wrong concept to love to love wrong concept
+wrong concept
+to love to love wrong concept

--- a/lyrics/Pure_Mids_-_The_Leader.txt
+++ b/lyrics/Pure_Mids_-_The_Leader.txt
@@ -9,8 +9,10 @@ who can i believe in if not you
 you're the only reason i'm true
 
 
-aw ah aw ah aw aw ah
-aw ah aw ah aw aw ah
+aw ah aw
+ah aw
+aw ah aw ah
+aw ah aw aw ah
 
 i've thought enough
 should i turn this around

--- a/lyrics/Ridgway_-_Fire_Inside.txt
+++ b/lyrics/Ridgway_-_Fire_Inside.txt
@@ -108,4 +108,5 @@ whoa oh oh oh oh
 
 find that fire find that fire
 
-find that fire find that fire find that fire find that fire
+find that fire find that fire find that fire
+find that fire

--- a/lyrics/Rxbyn_-_Bad_Side.txt
+++ b/lyrics/Rxbyn_-_Bad_Side.txt
@@ -73,6 +73,6 @@ get a taste of my bad side
 get a taste of my bad side
 just a taste of my bad side
 just a taste of my bad side
-you want a taste of my bad side hey
-just a taste of my bad side
+you want a taste of my bad side
+hey just a taste of my bad side
 taste of my bad side

--- a/lyrics/Wordsmith_-_The_Statement.txt
+++ b/lyrics/Wordsmith_-_The_Statement.txt
@@ -1,4 +1,7 @@
-live in a time of straight sin we got black sheep that don't fit in i'm like huhhh terrorists who wanna cut limbs don't zoom in to my true lens these loose ends are too grim to just comprehend i'm like huhhh oh lord it's getting worse cops out on that gang turf rich folks don't share first got planned parents don't need birth got prayers out and don't see church hands up and they shoot first another young life in that black hurst i'm too hurt i'm like huhhh
+live in a time of straight sin we got black sheep that don't fit in i'm like huhhh terrorists who wanna cut limbs don't
+zoom in to my true lens these loose ends are too grim to just comprehend i'm like huhhh oh lord it's getting worse cops out
+on that gang turf rich folks don't share first got planned parents don't need birth got prayers out and don't see church
+hands up and they shoot first another young life in that black hurst i'm too hurt i'm like huhhh
 
 ya'll better come my way ya'll better come way okay and say ya'll better come my way i'm gonna make a statement day by day
 ya'll better come my way ya'll better come way okay and say ya'll better come my way i'm gonna make a statement day by day
@@ -7,7 +10,10 @@ peace signs peace signs up put em in the air and go rise up yeah
 peace signs peace signs up put em in the air and go rise up yeah
 peace signs peace signs up put em in the air and go rise up yeah
 
-live in a time in true greed we got kids here who can't write and read i'm like huhhh disgust for that mistrust say one word and your handcuffed don't call bluff and you'll get struck and you're in court like huhhh live life with no limits my way no gimmicks pro league no scrimmage crunch time and i finish i'm that superstar no blemish i just own this no tenant you that background no sentence i'm the statement good riddance
+live in a time in true greed we got kids here who can't write and read i'm like huhhh disgust for that mistrust say one
+word and your handcuffed don't call bluff and you'll get struck and you're in court like huhhh live life with no limits my
+way no gimmicks pro league no scrimmage crunch time and i finish i'm that superstar no blemish i just own this no tenant
+you that background no sentence i'm the statement good riddance
 
 ya'll better come my way ya'll better come way okay and say ya'll better come my way i'm gonna make a statement day by day
 ya'll better come my way ya'll better come way okay and say ya'll better come my way i'm gonna make a statement day by day
@@ -20,7 +26,8 @@ stand up rise up peace signs up now whutsup
 stand up rise up peace signs up now whutsup
 stand up rise up peace signs up now whutsup
 
-live in a time of lost hope we got no ropes for that down slope we got many with plenty that say nope we got refugees on broke boats i'm like huhhhh real life with no tv millionaires stay greedy no love and there's no grub we got the homeless saying feed me
+live in a time of lost hope we got no ropes for that down slope we got many with plenty that say nope we got refugees on
+broke boats i'm like huhhhh real life with no tv millionaires stay greedy no love and there's no grub we got the homeless saying feed me
 
 ya'll better come my way ya'll better come way okay and say ya'll better come my way i'm gonna make a statement day by day
 ya'll better come my way ya'll better come way okay and say ya'll better come my way i'm gonna make a statement day by day


### PR DESCRIPTION
Hi, I think I found a little discrepancy in the data: I assumed that the lines under `lyrics/` match the lines under `annotations/`, but it turns out this is not always the case. Sometimes there are extra newlines in the lyrics, and sometimes they are missing, and there doesn't seem to be any obvious logic to it, so I guess this is by mistake. Since we probably don't want to mess with the annotations, I figured the right way to fix this is make the newlines in the lyrics consistent with the annotations. So this PR does that.